### PR TITLE
Kindlegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ To reverse proxy with our Letsencrypt docker container use the following locatio
         }
 ```
 
+## Kindlegen
+
+Kindlegen can be used for on the fly conversion of epub to mobi, we're unable to distribute kindlegen due to licensing, but if you download the Linux version from [here](https://www.amazon.com/gp/feature.html?docId=1000765211), untar the kindlegen binary into your `/config` folder it will be imported automatically for use within calibre-web.
 
 ## Info
 
@@ -98,6 +101,7 @@ To reverse proxy with our Letsencrypt docker container use the following locatio
 
 ## Versions
 
++ **21.01.18:** Add kindlegen import routine
 + **05.01.18:** Deprecate cpu_core routine lack of scaling.
 + **06.12.17:** Rebase to alpine 3.7.
 + **27.11.17:** Use cpu core counting routine to speed up build time.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To reverse proxy with our Letsencrypt docker container use the following locatio
 
 ## Kindlegen
 
-Kindlegen can be used for on the fly conversion of epub to mobi, we're unable to distribute kindlegen due to licensing, but if you download the Linux version from [here](https://www.amazon.com/gp/feature.html?docId=1000765211), untar the kindlegen binary into your `/config` folder it will be imported automatically for use within calibre-web.
+Kindlegen can be used for on the fly conversion of epub to mobi, we're unable to distribute kindlegen due to licensing, but if you download the Linux version from [here](https://www.amazon.com/gp/feature.html?docId=1000765211), and place the tar.gz file into your `/config` folder it will be imported automatically for use within calibre-web.
 
 ## Info
 

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -15,6 +15,11 @@
 [[ ! -L /app/calibre-web/calibre-web.log ]] && \
 	ln -s /config/calibre-web.log /app/calibre-web/calibre-web.log
 
+# copy kindlegen if present and make executable
+[[ -f /config/kindlegen ]] && \
+	mkdir -p /app/calibre-web/vendor && \
+	cp /config/kindlegen /app/calibre-web/vendor && \
+	chmod +x /app/calibre-web/vendor/kindlegen
 
 # permissions
 chown -R abc:abc \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -18,7 +18,7 @@
 # copy kindlegen if present and make executable
 [[ -f /config/kindlegen ]] && \
 	mkdir -p /app/calibre-web/vendor && \
-	cp /config/kindlegen /app/calibre-web/vendor && \
+	tar -xvf /config/kindlegen_linux_*.tar.gz -C /app/calibre-web/vendor/ kindlegen && \
 	chmod +x /app/calibre-web/vendor/kindlegen
 
 # permissions

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -16,7 +16,7 @@
 	ln -s /config/calibre-web.log /app/calibre-web/calibre-web.log
 
 # copy kindlegen if present and make executable
-[[ -f /config/kindlegen ]] && \
+[[ -f /config/kindlegen_linux_*.tar.gz ]] && \
 	mkdir -p /app/calibre-web/vendor && \
 	tar -xvf /config/kindlegen_linux_*.tar.gz -C /app/calibre-web/vendor/ kindlegen && \
 	chmod +x /app/calibre-web/vendor/kindlegen


### PR DESCRIPTION
Adds on the fly epub to mobi conversion,  Can't distribute kindlegen, so instead end-user untars it into their `/config` directory, where it is picked up and copied across to the target directory and made executable.