### PR TITLE
add calibre binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN \
 	libwebp \
 	libxml2 \
 	libxslt \
+	mesa-gl \
 	tiff \
 	zlib && \
  echo "**** install calibre-web ****" && \
@@ -63,6 +64,12 @@ RUN \
 	requirements.txt && \
  pip install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ echo "**** install GNU libc (aka glibc) ****" && \
+ apk --no-cache --allow-untrusted -X https://apkproxy.herokuapp.com/sgerrand/alpine-pkg-glibc add glibc glibc-bin && \
+ echo "**** install calibre binary ****" && \
+ wget -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | \
+     python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); \
+       exec(sys.stdin.read()); main(install_dir='/opt', isolated=True)" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,6 +46,7 @@ RUN \
 	libwebp \
 	libxml2 \
 	libxslt \
+	mesa-gl \
 	tiff \
 	zlib && \
  echo "**** install calibre-web ****" && \
@@ -66,6 +67,12 @@ RUN \
 	requirements.txt && \
  pip install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ echo "**** install GNU libc (aka glibc) ****" && \
+ apk --no-cache --allow-untrusted -X https://apkproxy.herokuapp.com/sgerrand/alpine-pkg-glibc add glibc glibc-bin && \
+ echo "**** install calibre binary ****" && \
+ wget -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | \
+     python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); \
+       exec(sys.stdin.read()); main(install_dir='/opt', isolated=True)" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -46,6 +46,7 @@ RUN \
 	libwebp \
 	libxml2 \
 	libxslt \
+	mesa-gl \
 	tiff \
 	zlib && \
  echo "**** install calibre-web ****" && \
@@ -66,6 +67,12 @@ RUN \
 	requirements.txt && \
  pip install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ echo "**** install GNU libc (aka glibc) ****" && \
+ apk --no-cache --allow-untrusted -X https://apkproxy.herokuapp.com/sgerrand/alpine-pkg-glibc add glibc glibc-bin && \
+ echo "**** install calibre binary ****" && \
+ wget -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | \
+     python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); \
+       exec(sys.stdin.read()); main(install_dir='/opt', isolated=True)" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \


### PR DESCRIPTION
Calibre's ebook-convert binary integrates beautifully with calibre-web and KindleGen has been depreciated. janeczku/calibre-web recommends using the significantly bloated technosoft2000/calibre-web in order to use Calibre's ebook-convert binary. This cures linuxserver/calibre-web of its singular limitation.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

