### PR TITLE
Install libnss3 in order to fix .pdf -> .mobi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get install -y \
 	imagemagick \
+	libnss3 && \
 	libxcomposite1 \
 	python3-minimal \
 	unrar && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get install -y \
 	imagemagick \
-	libnss3 && \
+	libnss3 \
 	libxcomposite1 \
 	python3-minimal \
 	unrar && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,6 +23,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get install -y \
 	imagemagick \
+	libnss3 \
 	libxcomposite1 \
 	python3-minimal \
 	unrar && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,6 +23,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get install -y \
 	imagemagick \
+	libnss3 \
 	libxcomposite1 \
 	python3-minimal \
 	unrar && \


### PR DESCRIPTION
## Description:
- Resolves #55 
- Converting `.pdf` to something, for example `.mobi` seems like a general-purpose feature/fix, so submitting a patch

## Benefits of this PR and context:
- Ability to convert `.pdf` to `.mobi`, or even `.epub`

## How Has This Been Tested?
- Add a `.pdf`, example https://web.mit.edu/alexmv/6.037/sicp.pdf
  - Not sure of the general case
- Try Edit metadata, convert to `.mobi`
- Will fail in logs with `ERROR in worker: Calibre failed with error: /app/calibre/bin/pdftohtml: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory`
  - Installing `libnss3` for this support seems like a trivial fix
- Install the library manually; `apt-get install libnss3`
- Repeat test process
- Conversion succeeds

## Source / References:
- Issue #55, fix suggested by @hholst80
