### PR TITLE
Missing ldap and sasl dev libraries dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN \
 	libnss3 \
 	libxcomposite1 \
 	python3-minimal \
+	libldap2-dev \
+	libsasl2-dev \
 	unrar && \
  echo "**** install calibre-web ****" && \
  if [ -z ${CALIBREWEB_RELEASE+x} ]; then \


### PR DESCRIPTION
Add missing ldap and sasl dev libraries on ubuntu dependencies when using optional python requirements python_ldap


