### PR TITLE
Werkzeug Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	git \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -49,6 +49,7 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	g++ \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -49,6 +49,7 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	g++ \


### PR DESCRIPTION
Pin Werkzeug version until next Calbre-web release.

With the most current `Werkzeug` release the latest release of calibre-web is broken.  It's  been fixed in upstream master so this is a temporary workaround until @OzzieIsaacs pushes a new release.

See:
https://github.com/janeczku/calibre-web/issues/1181
https://github.com/janeczku/calibre-web/issues/1188
https://github.com/janeczku/calibre-web/issues/1192

Closes https://github.com/linuxserver/docker-calibre-web/issues/61