### PR TITLE
Unpin Werkzeug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
- pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	git \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -49,7 +49,6 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
- pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	g++ \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -49,7 +49,6 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
- pip3 install Werkzeug==0.16.1 && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	g++ \


### PR DESCRIPTION
No longer necessary as upstream pushed new version with fix.

See https://github.com/linuxserver/docker-calibre-web/pull/62
