### PR TITLE
Kepubify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,14 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ echo "***install kepubify" && \
+ if [ -z ${KEPUBIFY_RELEASE+x} ]; then \
+    KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/geek1011/kepubify/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ curl -o \
+ /usr/bin/kepubify -L \
+	https://github.com/geek1011/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	git \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -50,6 +50,14 @@ RUN \
 	requirements.txt && \
  pip3 install --no-cache-dir -U -r \
 	optional-requirements.txt && \
+ echo "***install kepubify" && \
+ if [ -z ${KEPUBIFY_RELEASE+x} ]; then \
+    KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/geek1011/kepubify/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ curl -o \
+ /usr/bin/kepubify -L \
+	https://github.com/geek1011/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm && \
  echo "**** cleanup ****" && \
  apt-get -y purge \
 	g++ \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -54,8 +54,9 @@ app_setup_block: |
 
   **x86-64 only** We have implemented the optional ability to pull in the dependencies to enable ebook conversion utilising Calibre, this means if you don't require this feature the container isn't uneccessarily bloated but should you require it, it is easily available.
   This optional layer will be rebuilt automatically on our CI pipeline upon new Calibre releases so you can stay up to date.
-  To use this option add the optional environmental variable as detailed above to pull an addition docker layer to enable ebook conversion and then in the Calibre-Web admin page (Basic Configuration:External Binaries) set the path to converter tool to `/usr/bin/ebook-convert`  
+  To use this option add the optional environmental variable as detailed above to pull an addition docker layer to enable ebook conversion and then in the Calibre-Web admin page (Basic Configuration:External Binaries) set the **Path to Calibre E-Book Converter** to `/usr/bin/ebook-convert`  
   
+  **x86-64 & arm32v7 only** This image contains the [kepubify](https://pgaskin.net/kepubify/) ebook conversion tool (MIT License) to convert epub to kepub.  In the Calibre-Web admin page (Basic Configuration:External Binaries) set the **Path to Kepubify E-Book Converter** to `/usr/bin/kepubify`
 
   To reverse proxy with our Letsencrypt docker container we include a preconfigured reverse proxy config, for other instances of Nginx use the following location block:
   ```
@@ -70,6 +71,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.06.20:", desc: "Add kepubify for x86-64 and arm32v7" }
   - { date: "06.05.20:", desc: "Add libxslt1.1 and update ImageMagick policy" }
   - { date: "19.01.20:", desc: "Adding LDAP libs." }
   - { date: "13.10.19:", desc: "Migrate to Python3." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -38,6 +38,11 @@
 [[ ! -L /app/calibre-web/gdrive.db ]] && \
 	ln -s /config/gdrive.db /app/calibre-web/gdrive.db
 
+# check if kepubify is present and if so make executable
+[[ -f /usr/bin/kepubify ]] && \
+[[ ! -x /usr/bin/kepubify ]] && \
+	chmod +x /usr/bin/kepubify
+
 # permissions
 chown -R abc:abc \
 	/config \


### PR DESCRIPTION
Add kepubify to x64 and arm32 images.  Currently no binary for aarch64.  Hopefully one will be produced at next version release.

See https://github.com/linuxserver/docker-calibre-web/issues/81

Closes https://github.com/linuxserver/docker-calibre-web/issues/80