### PR TITLE
Remove extra volume from the Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8083
-VOLUME /books /config
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -83,4 +83,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8083
-VOLUME /books /config
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -83,4 +83,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8083
-VOLUME /books /config
+VOLUME /config


### PR DESCRIPTION
## Description:
Specifying the volume in the Dockerfile is unnecessary and can lead to excessive orphaned volume if the user chooses to use different paths at runtime.

## Benefits of this PR and context:
The `books` volume are actually not used by the initial container and are completely dependent on how users configure calibre-web.

This also allows user the flexibility to use the same volume for downloads and media (to solve the hardlink issue) without having the container create unnecessary volumes.

Removing the volume from the Dockerfile does not prevent users from having the README instructions succeed, but does allow for more flexibility without the creation of unnecessary unused volumes.

## How Has This Been Tested?
Built the docker container and verified no extra volumes were created.


## Source / References:
*https://github.com/linuxserver/docker-beets/pull/76
*https://github.com/linuxserver/docker-sonarr/pull/133
