### PR TITLE
Add libxrandr2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
 	libxslt1.1 \
 	libldap-2.4-2 \
 	libsasl2-2 \
+	libxrandr2 \
 	python3-minimal \
 	python3-pkg-resources \
 	unrar && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,6 +30,7 @@ RUN \
 	libsasl2-2 \
 	libxcomposite1 \
 	libxi6 \
+	libxrandr2 \
 	libxslt1.1 \
 	python3-minimal \
 	python3-pkg-resources \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -32,6 +32,7 @@ RUN \
 	libsasl2-2 \
 	libxcomposite1 \
 	libxi6 \
+	libxrandr2 \
 	libxslt1.1 \
 	python3-minimal \
     python3-pkg-resources \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,6 +77,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.02.21:", desc: "Add libxrandr2"}
   - { date: "25.01.21:", desc: "Add nightly tag"}
   - { date: "19.01.21:", desc: "Add python3-pkg-resources"}
   - { date: "13.01.21:", desc: "Rebase to Ubuntu Focal, see [here](https://docs.linuxserver.io/faq#my-host-is-incompatible-with-images-based-on-ubuntu-focal) for troubleshooting armhf." }


### PR DESCRIPTION
Necessary to convert to pdf.

Closes https://github.com/linuxserver/docker-calibre-web/issues/124 for nightly branch.