### PR TITLE
Pdf and ghostscript 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
   echo "**** install runtime packages ****" && \
   apt-get install -y --no-install-recommends \
     imagemagick \
+    ghostscript \
     libldap-2.5-0 \
     libnss3 \
     libsasl2-2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN \
     libxcomposite1 \
     libxi6 \
     libxrandr2 \
+    libxkbfile-dev \
     libxslt1.1 \
+    libxtst6 \
     python3-minimal \
     python3-pip \
     python3-pkg-resources \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,7 +30,9 @@ RUN \
     libxcomposite1 \
     libxi6 \
     libxrandr2 \
+    libxkbfile-dev \
     libxslt1.1 \
+    libxtst6 \
     python3-minimal \
     python3-pip \
     python3-pkg-resources \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -24,6 +24,7 @@ RUN \
   echo "**** install runtime packages ****" && \
   apt-get install -y --no-install-recommends \
     imagemagick \
+    ghostscript \
     libldap-2.5-0 \
     libnss3 \
     libsasl2-2 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,6 +26,7 @@ RUN \
   echo "**** install runtime packages ****" && \
   apt-get install -y --no-install-recommends \
     imagemagick \
+    ghostscript \
     libldap-2.5-0 \
     libnss3 \
     libsasl2-2 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -32,7 +32,9 @@ RUN \
     libxcomposite1 \
     libxi6 \
     libxrandr2 \
+    libxkbfile-dev \
     libxslt1.1 \
+    libxtst6 \
     python3-minimal \
     python3-pip \
     python3-pkg-resources \

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **27.12.22:** - Add ghostscript, libxtst6, libxkbfile-dev.
 * **20.12.22:** - Improve init script and prevent harmless error.
 * **22.10.22:** - Rebase to jammy. Upgrade to s6v3. Clean up build dependencies.
 * **04.11.21:** - Fix pip arguments

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -67,6 +67,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "27.12.22:", desc: "Add ghostscript, libxtst6, libxkbfile-dev."}
   - { date: "20.12.22:", desc: "Improve init script and prevent harmless error."}
   - { date: "22.10.22:", desc: "Rebase to jammy. Upgrade to s6v3. Clean up build dependencies."}
   - { date: "04.11.21:", desc: "Fix pip arguments"}


### PR DESCRIPTION
reported in discord
https://discord.com/channels/354974912613449730/506925392603512839/1057327723585998888

The following error-message shows up:
[2022-12-26 16:47:51,365] WARN {cps.uploader:229} Cannot extract cover image, using default: MagickReadImage returns false, but did not raise ImageMagick exception. This can occur when a delegate is missing, or returns EXIT_SUCCESS without generating a raster.
[2022-12-26 16:47:51,366] WARN {cps.uploader:230} On Windows this error could be caused by missing ghostscript

we ignore deps now, which caused imagemagick (which previously installed ghostscript) to no longer install it.

resolves https://github.com/linuxserver/docker-calibre-web/issues/222
resolves https://github.com/linuxserver/docker-calibre-web/issues/220
resolves https://github.com/linuxserver/docker-calibre-web/issues/204