### PR TITLE
calibre binary

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,7 +66,7 @@ app_setup_block: |
 
   **64bit only** We have implemented the optional ability to pull in the dependencies to enable ebook conversion utilising Calibre, this means if you don't require this feature the container isn't uneccessarily bloated but should you require it, it is easily available.
   This optional layer will be rebuilt automatically on our CI pipeline upon new Calibre releases so you can stay up to date.
-  To use this option add the optional environmental variable as shown in the docker-mods section to pull an addition docker layer to enable ebook conversion and then in the Calibre-Web admin page (Basic Configuration:External Binaries) set the **Path to Calibre E-Book Converter** to `/usr/bin/ebook-convert`
+  To use this option add the optional environmental variable as shown in the docker-mods section to pull an addition docker layer to enable ebook conversion and then in the Calibre-Web admin page (Basic Configuration:External Binaries) set the **Path to Calibre E-Book Converter** to `/usr/bin/ebook-convert` on versions 0.6.22 and lower. For 0.6.23 and higher, set the directory, `/usr/bin/` only.
 
   This image contains the [kepubify](https://pgaskin.net/kepubify/) ebook conversion tool (MIT License) to convert epub to kepub.  In the Calibre-Web admin page (Basic Configuration:External Binaries) set the **Path to Kepubify E-Book Converter** to `/usr/bin/kepubify`
 


### PR DESCRIPTION
in 0.6.23 a folder is expected for calibre binaries, rather than the path to the binary (TBH this might apply to 0.6.22 as well, i only just noticed upon updating to 0.6.23)
![image](https://github.com/user-attachments/assets/69bad1d1-6ab0-49ae-85b3-e8e5dd181518)

