### PR TITLE
add xdg-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN \
     libsasl2-2 \
     libxi6 \
     libxslt1.1 \
-    python3-venv && \
+    python3-venv \
+    xdg-utils && \
   echo "**** install calibre-web ****" && \
   if [ -z ${CALIBREWEB_RELEASE+x} ]; then \
     CALIBREWEB_RELEASE=$(curl -sX GET "https://api.github.com/repos/janeczku/calibre-web/releases/latest" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,7 +34,8 @@ RUN \
     libsasl2-2 \
     libxi6 \
     libxslt1.1 \
-    python3-venv && \
+    python3-venv \
+    xdg-utils && \
   echo "**** install calibre-web ****" && \
   if [ -z ${CALIBREWEB_RELEASE+x} ]; then \
     CALIBREWEB_RELEASE=$(curl -sX GET "https://api.github.com/repos/janeczku/calibre-web/releases/latest" \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -73,6 +73,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "26.08.24:", desc: "Add new dep, xdg-utils."}
   - { date: "07.07.24:", desc: "Add new dep, libmagic1."}
   - { date: "17.10.23:", desc: "Remove some packages that are required by the calibre mod but not the base container."}
   - { date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar). Switch to Python virtual environment."}


### PR DESCRIPTION
resolves https://github.com/linuxserver/docker-calibre-web/issues/298

somehow we have users facing an issue where the, broadly considered benign, desktop issue prevents the container from starting. Multiple people in the issue claim this resolves the issue. It doesn't make any sense to me, but as we all know, some of the nas units are stupid in how they function, so maybe it's legit.